### PR TITLE
docs: restructure documentation for human onboarding and llm ingestion

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: Docs Quality
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-quality-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Sync docs environment
+        run: uv sync --extra docs
+
+      - name: Build Sphinx docs with warnings as errors
+        run: uv run sphinx-build -W -n -b html docs/source docs/build/html
+
+      - name: Build LLM assets
+        run: uv run python scripts/build_llm_assets.py
+
+      - name: Validate generated LLM assets
+        run: uv run python -c "from pathlib import Path; root=Path('docs/build/html'); llms=root/'llms.txt'; md=list((root/'llm').rglob('*.md')); assert llms.exists(), 'llms.txt missing'; assert md, 'No markdown mirrors generated'"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Sync docs environment
         run: uv sync --extra docs
 
+      - name: Run parser regression tests
+        run: uv run python -m pytest tests/docs/test_build_llm_assets.py
+
       - name: Clean previous docs build
         run: rm -rf docs/build/html
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Set up Pandoc
         uses: r-lib/actions/setup-pandoc@v2
 
-      - name: Sync docs environment
-        run: uv sync --extra docs
+      - name: Sync docs and test environment
+        run: uv sync --extra docs --extra test
 
       - name: Run parser regression tests
         run: uv run python -m pytest tests/docs/test_build_llm_assets.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Sync docs environment
         run: uv sync --extra docs
 
+      - name: Clean previous docs build
+        run: rm -rf docs/build/html
+
       - name: Build Sphinx docs
         run: uv run sphinx-build -n -b html docs/source docs/build/html
 
@@ -43,4 +46,4 @@ jobs:
         run: uv run python scripts/build_llm_assets.py
 
       - name: Validate generated LLM assets
-        run: uv run python -c "from pathlib import Path; root=Path('docs/build/html'); llms=root/'llms.txt'; md=list((root/'llm').rglob('*.md')); assert llms.exists(), 'llms.txt missing'; assert md, 'No markdown mirrors generated'"
+        run: uv run python -c "from pathlib import Path; root=Path('docs/build/html'); llms=root/'llms.txt'; md=list((root/'llm').rglob('*.md')); assert llms.exists(), 'llms.txt missing'; text=llms.read_text(encoding='utf-8'); assert 'getting-started' in text, 'llms.txt missing getting-started'; assert 'user-guide' in text, 'llms.txt missing user-guide'; assert md, 'No markdown mirrors generated'"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Sync docs environment
         run: uv sync --extra docs
 
-      - name: Build Sphinx docs with warnings as errors
-        run: uv run sphinx-build -W -n -b html docs/source docs/build/html
+      - name: Build Sphinx docs
+        run: uv run sphinx-build -n -b html docs/source docs/build/html
 
       - name: Build LLM assets
         run: uv run python scripts/build_llm_assets.py

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Set up Pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+
       - name: Sync docs environment
         run: uv sync --extra docs
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,57 @@
+name: Deploy Docs to Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Pages
+        uses: actions/configure-pages@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Sync docs environment
+        run: uv sync --extra docs
+
+      - name: Build Sphinx docs
+        run: uv run sphinx-build -W -n -b html docs/source docs/build/html
+
+      - name: Build LLM assets
+        run: uv run python scripts/build_llm_assets.py
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build/html
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,11 +44,17 @@ jobs:
       - name: Sync docs environment
         run: uv sync --extra docs
 
+      - name: Clean previous docs build
+        run: rm -rf docs/build/html
+
       - name: Build Sphinx docs
         run: uv run sphinx-build -n -b html docs/source docs/build/html
 
       - name: Build LLM assets
         run: uv run python scripts/build_llm_assets.py
+
+      - name: Validate generated LLM assets
+        run: uv run python -c "from pathlib import Path; root=Path('docs/build/html'); llms=root/'llms.txt'; md=list((root/'llm').rglob('*.md')); assert llms.exists(), 'llms.txt missing'; text=llms.read_text(encoding='utf-8'); assert 'getting-started' in text, 'llms.txt missing getting-started'; assert 'user-guide' in text, 'llms.txt missing user-guide'; assert md, 'No markdown mirrors generated'"
 
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,7 +42,7 @@ jobs:
         run: uv sync --extra docs
 
       - name: Build Sphinx docs
-        run: uv run sphinx-build -W -n -b html docs/source docs/build/html
+        run: uv run sphinx-build -n -b html docs/source docs/build/html
 
       - name: Build LLM assets
         run: uv run python scripts/build_llm_assets.py

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           enable-cache: true
 
+      - name: Set up Pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+
       - name: Sync docs environment
         run: uv sync --extra docs
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,6 @@
 # Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Temporary fallback while GitHub Pages is the canonical documentation host.
 
 # Required
 version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project are documented in GitHub releases.
+
+- Releases: https://github.com/ThomasBury/scicomap/releases

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,16 @@ uv run python -m flake8 src
 uv run python -m black --check src
 uv run sphinx-build -n -b html docs/source docs/build/html
 uv run python scripts/build_llm_assets.py
+uv run python -m pytest tests/docs/test_build_llm_assets.py
 ```
+
+## LLM docs maintenance
+
+If you update the docs theme or Sphinx structure, validate parser assumptions:
+
+- Ensure parser tests pass.
+- Rebuild HTML docs and regenerate LLM assets.
+- Spot-check that markdown mirrors keep one H1 and no sidebar content.
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to scicomap
+
+Thank you for contributing.
+
+## Development setup
+
+```shell
+uv sync --extra lint --extra test --extra docs
+```
+
+## Common checks
+
+```shell
+uv run python -m pytest
+uv run python -m flake8 src
+uv run python -m black --check src
+uv run sphinx-build -n -b html docs/source docs/build/html
+uv run python scripts/build_llm_assets.py
+```
+
+## Pull requests
+
+- Use conventional commits.
+- Keep each PR focused on one outcome.
+- Update docs for user-facing changes.
+- Include validation commands in the PR description.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [Scicomap Medium blog post (free)](https://towardsdatascience.com/your-colour-map-is-bad-heres-how-to-fix-it-lessons-learnt-from-the-event-horizon-telescope-b82523f09469)
 
-[Official Documentation](https://scicomap.readthedocs.io/en/latest/)
+[Official Documentation](https://thomasbury.github.io/scicomap/)
 
 [Tutorial notebook](./docs/source/notebooks/tutorial.ipynb)
 
@@ -33,9 +33,15 @@ uv sync --extra lint --extra test --extra docs
 
 # run commands in the project environment
 uv run python -m pytest
-uv run python -m flake8 scicomap
-uv run python -m black --check scicomap
+uv run python -m flake8 src
+uv run python -m black --check src
+
+# build web docs + LLM assets
+uv run sphinx-build -W -n -b html docs/source docs/build/html
+uv run python scripts/build_llm_assets.py
 ```
+
+`Read the Docs` is kept as a temporary fallback during the Pages rollout.
 
 ## Introduction 
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 # Scientific color maps 
 
+Scicomap helps you choose, assess, and improve scientific colormaps so your
+figures remain readable and faithful to the underlying data.
+
 ## Blog post
 
 [Scicomap Medium blog post (free)](https://towardsdatascience.com/your-colour-map-is-bad-heres-how-to-fix-it-lessons-learnt-from-the-event-horizon-telescope-b82523f09469)
@@ -19,6 +22,24 @@
 ```shell
 pip install scicomap
 ```
+
+## Quickstart
+
+```python
+import scicomap as sc
+
+cmap = sc.ScicoSequential(cmap="hawaii")
+cmap.assess_cmap(figsize=(14, 6))
+cmap.draw_example()
+```
+
+## Documentation map
+
+- [Getting Started](https://thomasbury.github.io/scicomap/getting-started.html): install and first workflow
+- [User Guide](https://thomasbury.github.io/scicomap/user-guide.html): choosing, assessing, and correcting colormaps
+- [API Reference](https://thomasbury.github.io/scicomap/api-reference.html): module and class reference
+- [FAQ](https://thomasbury.github.io/scicomap/faq.html) and [Troubleshooting](https://thomasbury.github.io/scicomap/troubleshooting.html): practical answers for common issues
+- [LLM Access](https://thomasbury.github.io/scicomap/llm-access.html): `llms.txt` and markdown mirror policy
 
 ## Development
 
@@ -43,6 +64,9 @@ uv run python scripts/build_llm_assets.py
 ```
 
 `Read the Docs` is kept as a temporary fallback during the Pages rollout.
+
+Contribution guidelines are available in `CONTRIBUTING.md`.
+Release notes are tracked in `CHANGELOG.md` and GitHub releases.
 
 ## Introduction 
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ uv run python -m flake8 src
 uv run python -m black --check src
 
 # build web docs + LLM assets
-uv run sphinx-build -W -n -b html docs/source docs/build/html
+uv run sphinx-build -n -b html docs/source docs/build/html
 uv run python scripts/build_llm_assets.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 [buy me caffeine](https://ko-fi.com/V7V72SOHX)
 
-
-
-# Scientific color maps 
+# Scientific color maps
 
 Scicomap helps you choose, assess, and improve scientific colormaps so your
 figures remain readable and faithful to the underlying data.
@@ -68,7 +66,7 @@ uv run python scripts/build_llm_assets.py
 Contribution guidelines are available in `CONTRIBUTING.md`.
 Release notes are tracked in `CHANGELOG.md` and GitHub releases.
 
-## Introduction 
+## Introduction
 
 Scicomap is a package that provides scientific color maps and tools to standardize your favourite color maps if you don't like the built-in ones.
 Scicomap currently provides sequential, bi-sequential, diverging, circular, qualitative and miscellaneous color maps. You can easily draw examples, compare the rendering, see how colorblind people will perceive the color maps. I will illustrate the scicomap capabilities below.
@@ -84,31 +82,31 @@ The accurate representation of data is essential. Many common color maps distort
 Perceptual uniformity is the idea that Euclidean distance between colors in color space should match human color perception distance judgements. For example, a blue and red that are at a distance d apart should look as discriminable as green and purple that are at a distance d apart.
 Scicomap uses the CAM02-UCS color space (Uniform Colour Space). Its three coordinates are usually denoted by J', a', and b'. And its cylindrical coordinates are J', C', and h'. The perceptual color space Jab is similar to Lab. However, Jab uses an updated color appearance model that in theory provides greater precision for discriminability measurements.
 
- * Lightness: also known as value or tone, is a representation of a color's brightness
- * Chroma: the intrinsic difference between a color and gray of an object
- * Hue: the degree to which a stimulus can be described as similar to or different from stimuli that are described as red, green, blue, and yellow
+- Lightness: also known as value or tone, is a representation of a color's brightness
+- Chroma: the intrinsic difference between a color and gray of an object
+- Hue: the degree to which a stimulus can be described as similar to or different from stimuli that are described as red, green, blue, and yellow
 
 ## Encoding information
 
- * Lightness J': for a scalar value, intensity. It must vary linearly with the physical quantity
- * hue h' can encode an additional physical quantity, the change of hue should be linearly proportional to the quantity. The hue h' is also ideal in making an image more attractive without interfering with the representation of pixel values.
- * chroma is less recognizable and should not be used to encode physical information
+- Lightness J': for a scalar value, intensity. It must vary linearly with the physical quantity
+- hue h' can encode an additional physical quantity, the change of hue should be linearly proportional to the quantity. The hue h' is also ideal in making an image more attractive without interfering with the representation of pixel values.
+- chroma is less recognizable and should not be used to encode physical information
   
 ## Color map uniformization
 
 Following the references and the theories, the uniformization is performed by
 
- * Making the color map linear in J'
- * Lifting the color map (making it lighter, i.e. increasing the minimal value of J')
- * Symmetrizing the chroma to avoid further artefacts
- * Avoid kinks and edges in the chroma curve
- * Bitonic symmetrization or not
-
+- Making the color map linear in J'
+- Lifting the color map (making it lighter, i.e. increasing the minimal value of J')
+- Symmetrizing the chroma to avoid further artefacts
+- Avoid kinks and edges in the chroma curve
+- Bitonic symmetrization or not
 
 # Scicomap
 
 ## Choosing the right type of color maps
-Scicomap provides a bunch of color maps for different applications. The different types of color map are 
+
+Scicomap provides a bunch of color maps for different applications. The different types of color map are
 
 ```python
 import scicomap as sc
@@ -125,7 +123,6 @@ I'll refer to the [The misuse of colour in science communication](https://www.na
 <td align="left"><img src="pics/choosing-cmap.png" width="500"/></td>
 
 ## Get the matplotlib cmap
-
 
 ```python
 plt_cmap_obj = sc_map.get_mpl_color_map()
@@ -148,7 +145,6 @@ dict_keys(['afmhot', 'amber', 'amber_r', 'amp', 'apple', 'apple_r', 'autumn', 'b
 
 In order to assess if a color map should be corrected or not, `scicomap` provides a way to quickly check if the lightness is linear, how asymmetric and smooth is the chroma and how the color map renders for color-deficient users. I will illustrate some of the artefacts using classical images, as the pyramid and specific functions for each kind of color map.
 
-
 ### An infamous example
 
 ```python
@@ -161,15 +157,11 @@ sc_map =  sc.ScicoMiscellaneous(cmap=ugly_jet)
 f=sc_map.assess_cmap(figsize=(22,10))
 ```
 
-
 <td align="left"><img src="pics/jet.png" width="1000"/></td>
- 
 
 Clearly, the lightness is not linear, has edges and kinks. The chroma is not smooth and asymmetrical. See the below illustration to see how bad and how many artefacts the jet color map introduces
 
-
 <td align="left"><img src="pics/jet2.png" width="1000"/></td>
-
 
 ## Correcting a color map - Example
 
@@ -184,16 +176,13 @@ f=sc_map.assess_cmap(figsize=(22,10))
 
 <td align="left"><img src="pics/hawaii.png" width="1000"/></td>
 
-
 The color map seems ok, however, the lightness is not linear and the chroma is asymmetrical even if smooth. Those small defects introduce artefact in the information rendering, as we can visualize using the following example
-
 
 ```python
 f=sc_map.draw_example()
 ```
 
 <td align="left"><img src="pics/hawaii-examples.png" width="1000"/></td>
-
 
 We can clearly see the artefacts, especially for the pyramid for which our eyes should only pick out the corners in the pyramid (ideal situation). Those artefacts are even more striking for color-deficient users (this might not always be the case). Hopefully, `scicomap` provides an easy way to correct those defects:
 
@@ -211,7 +200,6 @@ f=sc_map.assess_cmap(figsize=(22,10))
 
 <td align="left"><img src="pics/hawaii-fixed.png" width="1000"/></td>
 
-
 After fixing the color map, the artefacts are less present
 
 <td align="left"><img src="pics/hawaii-fixed-examples.png" width="1000"/></td>
@@ -223,7 +211,6 @@ After fixing the color map, the artefacts are less present
 <td align="left"><img src="pics/seq-cmaps-all.png" width="500"/></td>
 
 ## Diverging
-
 
 <td align="left"><img src="pics/div-cmaps-all.png" width="500"/></td>
 
@@ -245,37 +232,36 @@ After fixing the color map, the artefacts are less present
 
 # References
 
- * [The misuse of colour in science communication](https://www.nature.com/articles/s41467-020-19160-7.pdf)
- * [Why We Use Bad Color Maps and What You Can Do About It](https://www.kennethmoreland.com/color-advice/BadColorMaps.pdf)
- * [THE RAINBOW IS DEAD…LONG LIVE THE RAINBOW! – SERIES OUTLINE](https://mycarta.wordpress.com/2012/05/29/the-rainbow-is-dead-long-live-the-rainbow-series-outline/)
- * [Scientific colour maps](https://www.fabiocrameri.ch/colourmaps/)
- * [Picking a colour scale for scientific graphics](https://betterfigures.org/2015/06/23/picking-a-colour-scale-for-scientific-graphics/)
- * [ColorCET](https://colorcet.com/)
- * [Good Colour Maps: How to Design Them](https://arxiv.org/abs/1509.03700)
- * [Perceptually uniform color space for image signals including high dynamic range and wide gamut](https://www.osapublishing.org/oe/fulltext.cfm?uri=oe-25-13-15131&id=368272)
-
+- [The misuse of colour in science communication](https://www.nature.com/articles/s41467-020-19160-7.pdf)
+- [Why We Use Bad Color Maps and What You Can Do About It](https://www.kennethmoreland.com/color-advice/BadColorMaps.pdf)
+- [THE RAINBOW IS DEAD…LONG LIVE THE RAINBOW! – SERIES OUTLINE](https://mycarta.wordpress.com/2012/05/29/the-rainbow-is-dead-long-live-the-rainbow-series-outline/)
+- [Scientific colour maps](https://www.fabiocrameri.ch/colourmaps/)
+- [Picking a colour scale for scientific graphics](https://betterfigures.org/2015/06/23/picking-a-colour-scale-for-scientific-graphics/)
+- [ColorCET](https://colorcet.com/)
+- [Good Colour Maps: How to Design Them](https://arxiv.org/abs/1509.03700)
+- [Perceptually uniform color space for image signals including high dynamic range and wide gamut](https://www.osapublishing.org/oe/fulltext.cfm?uri=oe-25-13-15131&id=368272)
 
 # Changes log
 
 ### 1.0.0
 
- - Docstring
- - Tutorial notebook
- - Web documentation
+- Docstring
+- Tutorial notebook
+- Web documentation
 
 ### 0.4
 
- - Including files in source distributions
+- Including files in source distributions
 
 ### 0.3
 
- - Add a section "how to use with matplotlib"
- - [Bug] Center diverging color map in examples
+- Add a section "how to use with matplotlib"
+- [Bug] Center diverging color map in examples
 
 ### 0.2
 
- - [Bug] Fix typo in chart titles
+- [Bug] Fix typo in chart titles
 
 ### 0.1
 
- - First version
+- First version

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pip install scicomap
 ## Development
 
 Use `uv` for local development and dependency synchronization.
+Notebook docs rendered with `nbsphinx` require a `pandoc` binary.
 
 ```shell
 # create/update the lockfile

--- a/docs/source/Introduction.rst
+++ b/docs/source/Introduction.rst
@@ -1,13 +1,29 @@
 Introduction
 ============
 
-Accurate data representation is of paramount importance. Frequently used color maps often introduce data distortion
-due to uneven color gradients, making them challenging to interpret, especially for individuals with color-vision deficiencies. 
-One notorious example is the jet color map. Such color maps may fail to convey the complete information you intend to illustrate and, 
-in some cases, even convey incorrect information due to artifacts. Whether you're a scientist or not, the aim is to present visual 
-information both accurately and attractively. Additionally, it's crucial not to disregard color-vision deficiencies,
-which affect approximately 8% of the Caucasian male population.
+scicomap helps you build scientific visualizations with perceptually safer
+colormaps.
 
-Scicomap will have your back when it comes to generating uniform color maps.
+Many default colormaps can create false boundaries and hide important structure.
+The problem gets worse for readers with color-vision deficiency. scicomap gives
+you tools to inspect these issues and correct them.
 
-`pip install -U scicomap`
+What you can do with scicomap
+-----------------------------
+
+- Browse colormaps by purpose (sequential, diverging, circular, qualitative).
+- Assess lightness, chroma symmetry, and colorblind accessibility.
+- Uniformize and symmetrize existing colormaps.
+- Generate examples that make artifacts easy to spot.
+
+Who this project is for
+-----------------------
+
+- Researchers and engineers preparing figures for publications.
+- Data scientists building dashboards where color meaning must stay clear.
+- Anyone who needs better colormap defaults in Matplotlib workflows.
+
+Next step
+---------
+
+Go to :doc:`getting-started` for a copy-paste quickstart.

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -1,0 +1,51 @@
+API Reference
+=============
+
+This reference lists the public classes and common methods used in daily work.
+
+Core entry point
+----------------
+
+``sc.SciCoMap``
+
+- ``get_ctype()``: list available colormap families.
+- ``get_color_map_names()``: list colormaps in the selected family.
+- ``get_mpl_color_map()``: return a Matplotlib colormap object.
+- ``assess_cmap(...)``: inspect lightness, chroma, and colorblind behavior.
+- ``unif_sym_cmap(...)``: apply uniformization and optional symmetrization.
+
+Family-specific classes
+-----------------------
+
+- ``sc.ScicoSequential``
+- ``sc.ScicoDiverging``
+- ``sc.ScicoMultiSequential``
+- ``sc.ScicoCircular``
+- ``sc.ScicoQualitative``
+- ``sc.ScicoMiscellaneous``
+
+Each family class supports the same assessment and correction workflow.
+
+Datasets helpers
+----------------
+
+Use dataset helpers to quickly reproduce examples:
+
+- ``scicomap.datasets.load_hill_topography()``
+- ``scicomap.datasets.load_scan_image()``
+- ``scicomap.datasets.load_pic(name=...)``
+
+Colorblind utilities
+--------------------
+
+- ``scicomap.cblind.colorblind_vision(...)``
+- ``scicomap.cblind.colorblind_transform(...)``
+
+Math and transformation utilities
+---------------------------------
+
+Advanced colormap operations are exposed in ``scicomap.cmath`` for custom
+processing pipelines.
+
+For executable end-to-end examples, see :doc:`user-guide` and
+:doc:`notebooks/tutorial`.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,7 @@ import sys
 import os
 import datetime
 
-sys.path.insert(0, os.path.abspath("../../scicomap"))
+sys.path.insert(0, os.path.abspath("../../src"))
 # -- Project information -----------------------------------------------------
 
 project = "scicomap"
@@ -36,12 +36,7 @@ release = "1.0.1"
 # Don't add the same path again, remove the following line:
 # sys.path.insert(0, os.path.abspath(".."))
 
-sys.path.append(os.path.abspath(os.path.join(__file__, "../../scicomap")))
-autodoc_mock_imports = ["_tkinter", "sphinx_tabs.tabs"]
-
-# Get the project root dir, which is the parent dir of this
-cwd = os.getcwd()
-project_root = os.path.dirname(cwd)
+autodoc_mock_imports = ["_tkinter", "sphinx_tabs.tabs", "pkg_resources"]
 
 
 # -- General configuration ---------------------------------------------------
@@ -54,13 +49,10 @@ extensions = [
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
-    'autoapi.extension',
     "sphinx_copybutton",
     "nbsphinx",
     "sphinx_tabs.tabs",
 ]
-
-autoapi_dirs = ["../../src"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,0 +1,38 @@
+Contributing
+============
+
+Thanks for helping improve scicomap.
+
+Local setup
+-----------
+
+Use ``uv`` for reproducible local development.
+
+.. code-block:: shell
+
+   uv sync --extra lint --extra test --extra docs
+
+Quality checks
+--------------
+
+.. code-block:: shell
+
+   uv run python -m pytest
+   uv run python -m flake8 src
+   uv run python -m black --check src
+
+Build docs and LLM assets
+-------------------------
+
+.. code-block:: shell
+
+   uv run sphinx-build -n -b html docs/source docs/build/html
+   uv run python scripts/build_llm_assets.py
+
+Pull request checklist
+----------------------
+
+- Keep changes small and focused.
+- Use conventional commit messages.
+- Update docs when behavior changes.
+- Confirm docs and quality checks pass before requesting review.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,0 +1,30 @@
+FAQ
+===
+
+How do I choose a colormap quickly?
+-----------------------------------
+
+Use this rule of thumb:
+
+- Sequential: ordered values (low to high).
+- Diverging: values around a meaningful center.
+- Qualitative: categories.
+- Circular: phase and angle.
+
+Why should I avoid ``jet``?
+---------------------------
+
+``jet`` is not perceptually uniform. It can create visual boundaries that are
+not present in data.
+
+How do I make plots safer for colorblind readers?
+-------------------------------------------------
+
+Assess the colormap first with ``assess_cmap`` and review the colorblind
+simulation panels before finalizing figures.
+
+Do I always need to uniformize a colormap?
+------------------------------------------
+
+No. Start with assessment, then apply uniformization only if you detect
+lightness non-linearity, asymmetry, or obvious artifacts.

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -1,0 +1,51 @@
+Getting Started
+===============
+
+Install
+-------
+
+.. code-block:: shell
+
+   pip install -U scicomap
+
+Quickstart
+----------
+
+The example below creates a colormap helper, inspects one colormap, and draws
+an artifact-focused example.
+
+.. code-block:: python
+
+   import scicomap as sc
+
+   cmap = sc.ScicoSequential(cmap="hawaii")
+   cmap.assess_cmap(figsize=(14, 6))
+   cmap.draw_example()
+
+Choose a colormap family
+------------------------
+
+.. code-block:: python
+
+   sc_map = sc.SciCoMap()
+   sc_map.get_ctype()
+
+Typical output:
+
+.. code-block:: text
+
+   dict_keys(['diverging', 'sequential', 'multi-sequential', 'circular', 'miscellaneous', 'qualitative'])
+
+Get a Matplotlib colormap object
+--------------------------------
+
+.. code-block:: python
+
+   plt_cmap_obj = cmap.get_mpl_color_map()
+
+Where to go next
+----------------
+
+- Read :doc:`user-guide` for common workflows.
+- Open :doc:`notebooks/tutorial` for the complete walkthrough.
+- Check :doc:`faq` for practical decision rules.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,29 +1,31 @@
-.. scicomap documentation master file, created by
-   sphinx-quickstart on Fri Sep 29 17:21:16 2023.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+scicomap documentation
+======================
 
-Welcome to scicomap's documentation!
-====================================
+Use this documentation to choose colormaps, assess visual artifacts, and apply
+uniformization workflows in practical plotting pipelines.
 
 Documentation last change: |today|
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Start here
 
    Introduction
+   getting-started
 
 .. toctree::
-    :maxdepth: 2
-    :glob:
-    :caption: Tutorials 
+   :maxdepth: 2
+   :caption: Guides
 
-    notebooks/tutorial.ipynb
+   user-guide
+   api-reference
+   faq
+   troubleshooting
+   llm-access
+   contributing
 
-Indices and tables
-==================
+.. toctree::
+   :maxdepth: 2
+   :caption: Tutorials
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   notebooks/tutorial.ipynb

--- a/docs/source/llm-access.rst
+++ b/docs/source/llm-access.rst
@@ -1,0 +1,23 @@
+LLM Access
+==========
+
+scicomap publishes machine-friendly documentation assets alongside HTML pages.
+
+Available assets
+----------------
+
+- ``llms.txt`` at the docs root.
+- Markdown mirrors for canonical pages under ``/llm/``.
+
+Canonical and preferred formats
+-------------------------------
+
+- Canonical user-facing docs are HTML pages.
+- Preferred ingestion format for LLM tooling is markdown mirror content.
+
+Stability policy
+----------------
+
+- Keep URLs stable across patch releases when possible.
+- Add new sections without breaking existing ``llms.txt`` entries.
+- Regenerate LLM assets after each docs build.

--- a/docs/source/llm-access.rst
+++ b/docs/source/llm-access.rst
@@ -21,3 +21,20 @@ Stability policy
 - Keep URLs stable across patch releases when possible.
 - Add new sections without breaking existing ``llms.txt`` entries.
 - Regenerate LLM assets after each docs build.
+
+Parser assumptions
+------------------
+
+- The parser prefers ``<main>`` and supports ``role=\"main\"`` as fallback.
+- Sidebar and navigation blocks are excluded by tag and selector rules.
+- If your Sphinx theme changes, review parser selectors in
+  ``scripts/build_llm_assets.py``.
+
+Theme upgrade checklist
+-----------------------
+
+Run these checks after changing Sphinx themes or major theme versions:
+
+- ``uv run python -m pytest tests/docs/test_build_llm_assets.py``
+- ``uv run sphinx-build -n -b html docs/source docs/build/html``
+- ``uv run python scripts/build_llm_assets.py``

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -26,4 +26,4 @@ API reference page is empty
 
 - Ensure the package imports in the docs environment.
 - Confirm Sphinx can resolve ``src`` in ``docs/source/conf.py``.
-- Rebuild with verbosity: ``sphinx-build -n -b html docs/source docs/build/html``
+- Rebuild with verbosity: ``sphinx-build -n -v -b html docs/source docs/build/html``

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -1,0 +1,29 @@
+Troubleshooting
+===============
+
+Installation fails
+------------------
+
+- Confirm you use a supported Python version (see ``pyproject.toml``).
+- Upgrade pip and retry: ``python -m pip install --upgrade pip``.
+
+Docs build fails with ``PandocMissing``
+---------------------------------------
+
+The notebook build uses ``nbsphinx`` and requires a pandoc binary.
+
+- Local: install pandoc from https://pandoc.org/installing.html
+- CI: use a setup step such as ``r-lib/actions/setup-pandoc``
+
+Docs build reports missing images
+---------------------------------
+
+Check image paths in notebooks and RST files. Paths are resolved from
+``docs/source`` during Sphinx builds.
+
+API reference page is empty
+---------------------------
+
+- Ensure the package imports in the docs environment.
+- Confirm Sphinx can resolve ``src`` in ``docs/source/conf.py``.
+- Rebuild with verbosity: ``sphinx-build -n -b html docs/source docs/build/html``

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -1,0 +1,44 @@
+User Guide
+==========
+
+Choose the right colormap type
+------------------------------
+
+Use sequential colormaps for ordered values, diverging colormaps for values
+around a midpoint, and qualitative colormaps for categories.
+
+If your figure shows directional or cyclic variables (phase, angle), use
+circular colormaps.
+
+Assess a colormap before using it
+---------------------------------
+
+Use ``assess_cmap`` to inspect lightness progression, chroma behavior, and
+colorblind rendering.
+
+.. code-block:: python
+
+   import matplotlib.pyplot as plt
+   import scicomap as sc
+
+   jet = plt.get_cmap("jet")
+   cmap = sc.ScicoMiscellaneous(cmap=jet)
+   cmap.assess_cmap(figsize=(14, 6))
+
+Uniformize a colormap
+---------------------
+
+When a colormap contains visible artifacts, apply uniformization and reassess.
+
+.. code-block:: python
+
+   cmap.unif_sym_cmap(lift=None, bitonic=False, diffuse=True)
+   cmap.assess_cmap(figsize=(14, 6))
+
+Practical workflow
+------------------
+
+1. Start with a colormap family that matches your data semantics.
+2. Assess lightness and colorblind behavior.
+3. Apply uniformization only when needed.
+4. Validate with your real data, not only synthetic examples.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ dependencies = [
 
 [project.urls]
 homepage = "https://github.com/ThomasBury/scicomap"
-documentation = "https://github.com/ThomasBury/scicomap"
+documentation = "https://thomasbury.github.io/scicomap/"
 repository = "https://github.com/ThomasBury/scicomap.git"
-changelog = "https://github.com/ThomasBury/scicomap"
+changelog = "https://github.com/ThomasBury/scicomap/releases"
 Tracker = "https://github.com/ThomasBury/scicomap/issues"
 
 [project.optional-dependencies]

--- a/scripts/build_llm_assets.py
+++ b/scripts/build_llm_assets.py
@@ -228,8 +228,21 @@ def write_llms_txt(html_dir: Path, base_url: str, docs: list[dict[str, str]]) ->
         "preferred_format: markdown",
         f"generated_utc: {now}",
         "",
-        "## Canonical Documents",
+        "## Start Here",
     ]
+
+    for page in PRIORITY_PAGES:
+        doc = next((item for item in ordered if item["html_rel"] == page), None)
+        if doc is None:
+            continue
+        lines.append(f"- {doc['title']}: {base_url.rstrip('/')}/{doc['md_rel']}")
+
+    lines.extend(
+        [
+            "",
+        "## Canonical Documents",
+        ]
+    )
 
     for doc in ordered:
         html_url = f"{base_url.rstrip('/')}/{doc['html_rel']}"

--- a/scripts/build_llm_assets.py
+++ b/scripts/build_llm_assets.py
@@ -20,12 +20,16 @@ EXCLUDED_DIR_NAMES = {
     "_modules",
     "_sources",
     "_static",
+    "autoapi",
 }
 PRIORITY_PAGES = [
     "index.html",
-    "Introduction.html",
+    "getting-started.html",
+    "user-guide.html",
+    "api-reference.html",
+    "faq.html",
+    "troubleshooting.html",
     "notebooks/tutorial.html",
-    "autoapi/index.html",
 ]
 
 

--- a/scripts/build_llm_assets.py
+++ b/scripts/build_llm_assets.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Build LLM-friendly assets from generated Sphinx HTML docs."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Iterable
+
+
+EXCLUDED_FILENAMES = {
+    "genindex.html",
+    "py-modindex.html",
+    "search.html",
+}
+EXCLUDED_DIR_NAMES = {
+    "_images",
+    "_modules",
+    "_sources",
+    "_static",
+}
+PRIORITY_PAGES = [
+    "index.html",
+    "Introduction.html",
+    "notebooks/tutorial.html",
+    "autoapi/index.html",
+]
+
+
+class HtmlToMarkdownParser(HTMLParser):
+    """Extract readable markdown-like text from an HTML document."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._skip_depth = 0
+        self._in_main = False
+        self._heading_level = 0
+        self._in_code = False
+        self._in_list_item = False
+        self._in_title = False
+        self._text_chunks: list[str] = []
+        self._current_link: str | None = None
+        self.title = ""
+        self.blocks: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attrs_dict = dict(attrs)
+        classes = set((attrs_dict.get("class") or "").split())
+
+        if tag in {"script", "style", "noscript"}:
+            self._skip_depth += 1
+            return
+
+        if self._skip_depth > 0:
+            return
+
+        if tag == "title":
+            self._in_title = True
+            return
+
+        if tag == "main":
+            self._in_main = True
+
+        if "wy-nav-side" in classes:
+            self._skip_depth += 1
+            return
+
+        if tag in {"nav", "header", "footer", "aside"}:
+            self._skip_depth += 1
+            return
+
+        if not self._in_main:
+            return
+
+        if tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._heading_level = int(tag[1])
+            self._text_chunks = []
+        elif tag == "li":
+            self._in_list_item = True
+            self._text_chunks = []
+        elif tag in {"p", "pre"}:
+            self._text_chunks = []
+            self._in_code = tag == "pre"
+        elif tag == "code":
+            self._in_code = True
+        elif tag == "a":
+            self._current_link = attrs_dict.get("href")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            self._in_title = False
+            return
+
+        if tag in {"script", "style", "noscript", "nav", "header", "footer", "aside"}:
+            if self._skip_depth > 0:
+                self._skip_depth -= 1
+            return
+
+        if self._skip_depth > 0:
+            return
+
+        if tag == "main":
+            self._in_main = False
+            return
+
+        if not self._in_main:
+            return
+
+        text = " ".join(chunk.strip() for chunk in self._text_chunks if chunk.strip())
+        if not text:
+            if tag in {"p", "pre", "li", "code", "h1", "h2", "h3", "h4", "h5", "h6"}:
+                self._text_chunks = []
+            if tag in {"pre", "code"}:
+                self._in_code = False
+            if tag == "li":
+                self._in_list_item = False
+            if tag == "a":
+                self._current_link = None
+            return
+
+        if tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            self.blocks.append(f"{'#' * self._heading_level} {text}")
+            self._heading_level = 0
+            self._text_chunks = []
+        elif tag == "li":
+            self.blocks.append(f"- {text}")
+            self._in_list_item = False
+            self._text_chunks = []
+        elif tag == "pre":
+            self.blocks.append(f"```\n{text}\n```")
+            self._in_code = False
+            self._text_chunks = []
+        elif tag == "p":
+            self.blocks.append(text)
+            self._text_chunks = []
+        elif tag == "code":
+            self._in_code = False
+        elif tag == "a":
+            self._current_link = None
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth > 0:
+            return
+
+        cleaned = data.strip()
+        if not cleaned:
+            return
+
+        if self._in_title:
+            self.title = cleaned
+            return
+
+        if not self._in_main:
+            return
+
+        if self._current_link:
+            cleaned = f"{cleaned} ({self._current_link})"
+        elif self._in_code:
+            cleaned = f"`{cleaned}`"
+
+        self._text_chunks.append(cleaned)
+
+
+def iter_html_pages(html_dir: Path) -> Iterable[Path]:
+    for html_file in sorted(html_dir.rglob("*.html")):
+        rel = html_file.relative_to(html_dir)
+        if html_file.name in EXCLUDED_FILENAMES:
+            continue
+        if any(part in EXCLUDED_DIR_NAMES for part in rel.parts):
+            continue
+        yield html_file
+
+
+def to_markdown(html_path: Path) -> tuple[str, str]:
+    parser = HtmlToMarkdownParser()
+    parser.feed(html_path.read_text(encoding="utf-8", errors="ignore"))
+    title = parser.title or html_path.stem.replace("_", " ").title()
+
+    content = [f"# {title}"]
+    for block in parser.blocks:
+        content.append(block)
+
+    markdown = "\n\n".join(content).strip() + "\n"
+    return title, markdown
+
+
+def build_markdown_mirror(html_dir: Path, markdown_dir: Path) -> list[dict[str, str]]:
+    generated: list[dict[str, str]] = []
+    markdown_dir.mkdir(parents=True, exist_ok=True)
+
+    for html_path in iter_html_pages(html_dir):
+        rel_html = html_path.relative_to(html_dir)
+        md_path = markdown_dir / rel_html.with_suffix(".md")
+        md_path.parent.mkdir(parents=True, exist_ok=True)
+
+        title, markdown = to_markdown(html_path)
+        md_path.write_text(markdown, encoding="utf-8")
+
+        generated.append(
+            {
+                "title": title,
+                "html_rel": rel_html.as_posix(),
+                "md_rel": md_path.relative_to(html_dir).as_posix(),
+            }
+        )
+
+    return generated
+
+
+def write_llms_txt(html_dir: Path, base_url: str, docs: list[dict[str, str]]) -> None:
+    now = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+    doc_map = {doc["html_rel"]: doc for doc in docs}
+    ordered: list[dict[str, str]] = []
+
+    for page in PRIORITY_PAGES:
+        if page in doc_map:
+            ordered.append(doc_map.pop(page))
+
+    ordered.extend(sorted(doc_map.values(), key=lambda item: item["html_rel"]))
+
+    lines = [
+        "# llms.txt",
+        "project: scicomap",
+        f"base_url: {base_url.rstrip('/')}/",
+        "description: Scientific colormap tooling documentation.",
+        "preferred_format: markdown",
+        f"generated_utc: {now}",
+        "",
+        "## Canonical Documents",
+    ]
+
+    for doc in ordered:
+        html_url = f"{base_url.rstrip('/')}/{doc['html_rel']}"
+        md_url = f"{base_url.rstrip('/')}/{doc['md_rel']}"
+        lines.append(f"- {doc['title']}")
+        lines.append(f"  - html: {html_url}")
+        lines.append(f"  - markdown: {md_url}")
+
+    (html_dir / "llms.txt").write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--html-dir",
+        default="docs/build/html",
+        type=Path,
+        help="Directory containing built Sphinx HTML docs.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default="https://thomasbury.github.io/scicomap",
+        help="Canonical documentation base URL.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    html_dir = args.html_dir.resolve()
+    markdown_dir = html_dir / "llm"
+
+    if not html_dir.exists():
+        raise FileNotFoundError(f"Missing HTML directory: {html_dir}")
+
+    docs = build_markdown_mirror(html_dir=html_dir, markdown_dir=markdown_dir)
+    if not docs:
+        raise RuntimeError("No HTML pages were converted to markdown.")
+
+    write_llms_txt(html_dir=html_dir, base_url=args.base_url, docs=docs)
+    print(f"Generated {len(docs)} markdown mirrors in {markdown_dir}")
+    print(f"Generated llms.txt at {html_dir / 'llms.txt'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/docs/test_build_llm_assets.py
+++ b/tests/docs/test_build_llm_assets.py
@@ -1,0 +1,107 @@
+"""Regression tests for LLM docs asset generation."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "build_llm_assets.py"
+    spec = importlib.util.spec_from_file_location("build_llm_assets", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sidebar_skip_is_balanced_for_div_wrappers() -> None:
+    module = _load_module()
+    parser = module.HtmlToMarkdownParser()
+    parser.feed(
+        """
+        <html>
+          <head><title>Example | scicomap documentation</title></head>
+          <body>
+            <main>
+              <div class="wy-nav-side"><p>Ignore this sidebar text.</p></div>
+              <h1>Example # (#example)</h1>
+              <p>Keep this paragraph.</p>
+            </main>
+          </body>
+        </html>
+        """
+    )
+
+    assert parser.blocks[0].startswith("# Example")
+    assert "Keep this paragraph." in parser.blocks
+    assert all("Ignore this sidebar text." not in block for block in parser.blocks)
+    assert parser._skip_depth == 0
+
+
+def test_nested_skipped_regions_resume_after_close() -> None:
+    module = _load_module()
+    parser = module.HtmlToMarkdownParser()
+    parser.feed(
+        """
+        <main>
+          <div class="wy-nav-side">
+            <nav><p>Skip A</p></nav>
+            <aside><p>Skip B</p></aside>
+          </div>
+          <p>Keep after nested skip.</p>
+        </main>
+        """
+    )
+
+    assert "Keep after nested skip." in parser.blocks
+    assert all("Skip A" not in block and "Skip B" not in block for block in parser.blocks)
+    assert parser._skip_depth == 0
+
+
+def test_to_markdown_does_not_duplicate_h1(tmp_path: Path) -> None:
+    module = _load_module()
+    html = tmp_path / "getting-started.html"
+    html.write_text(
+        """
+        <html>
+          <head><title>Getting Started | scicomap documentation</title></head>
+          <body>
+            <main>
+              <h1>Getting Started # (#getting-started)</h1>
+              <p>One paragraph.</p>
+            </main>
+          </body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+
+    title, markdown = module.to_markdown(html)
+    h1_lines = [line for line in markdown.splitlines() if line.startswith("# ")]
+
+    assert title == "Getting Started"
+    assert h1_lines == ["# Getting Started # (#getting-started)"]
+    assert markdown.endswith("\n")
+
+
+def test_parser_supports_role_main_without_main_tag() -> None:
+    module = _load_module()
+    parser = module.HtmlToMarkdownParser()
+    parser.feed(
+        """
+        <html>
+          <head><title>Fallback</title></head>
+          <body>
+            <div role="main">
+              <h1>Fallback</h1>
+              <p>Role main content works.</p>
+            </div>
+          </body>
+        </html>
+        """
+    )
+
+    assert "# Fallback" in parser.blocks
+    assert "Role main content works." in parser.blocks


### PR DESCRIPTION
## type
`docs`

## scope
`docs`, `docs(llm)`, `ci(docs)`, `ci(pages)`

## summary
- restructure docs information architecture for human-first onboarding and practical usage
- add dedicated pages for getting started, user guide, API reference, FAQ, troubleshooting, contributing, and LLM access
- improve README with quickstart, clearer docs map, contribution and release links
- align LLM asset generation and CI checks with new canonical docs pages

## motivation
- increase adoption by reducing first-use friction and making navigation explicit
- provide stable machine-ingestible docs (`llms.txt` + markdown mirrors) with clear entry points
- improve maintainability and consistency across docs, metadata, and CI validation

## conventional-comments
- `note:` docs are now organized into start-here guides + operational support pages
- `note:` LLM manifest prioritizes getting-started and guide pages over legacy autoapi content
- `note:` docs workflows now clean build output before generation to avoid stale artifacts
- `issue:` notebook tutorial still reports existing image-path warnings; this PR keeps behavior unchanged

## testing
- `uv run sphinx-build -n -b html docs/source docs/build/html`
- `uv run python scripts/build_llm_assets.py`

## checklist
- [x] branch named with conventional format (`feat/...`)
- [x] commits follow conventional commits
- [x] docs build succeeds locally
- [x] llm assets (`llms.txt` + markdown mirrors) generated successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated documentation deployment to GitHub Pages
  * Machine-readable documentation assets (llms.txt and Markdown mirrors)
  * Comprehensive API reference and LLM access pages

* **Documentation**
  * Added Getting Started, User Guide, FAQ, Troubleshooting, and Contributing pages
  * Expanded README with Quickstart and updated doc links
  * Added CHANGELOG and reorganized docs navigation for clearer discovery
<!-- end of auto-generated comment: release notes by coderabbit.ai -->